### PR TITLE
Work reasonably even if `package.directories.test` does not end with path separator

### DIFF
--- a/intelli-espower-loader.js
+++ b/intelli-espower-loader.js
@@ -27,5 +27,5 @@ assert.equal(typeof directories.test, "string", 'You should setting `directories
 var testDirectory = directories.test;
 require('espower-loader')({
     cwd: process.cwd(),
-    pattern: testDirectory + "**" + pather.sep + "*.js"
+    pattern: testDirectory + ((testDirectory.lastIndexOf(pather.sep, 0) === 0) ? '' : pather.sep) + "**" + pather.sep + "*.js"
 });


### PR DESCRIPTION
It's nice to work reasonably even if `package.directories.test` does not end with path separator.
Thanks!
