### PR TITLE
Update espower-loader to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "url": "https://github.com/azu/intelli-espower-loader/issues"
   },
   "peerDependencies": {
-    "espower-loader": "~0.7.0"
+    "espower-loader": "^0.8.0"
   },
   "devDependencies": {
-    "mocha": "^1.20.1"
+    "mocha": "^1.21.4"
   }
 }


### PR DESCRIPTION
Today I've released [power-assert 0.8.0](https://github.com/twada/power-assert/releases/tag/v0.8.0).
So, bumping up espower-loader peerDependency to 0.8.0
Thanks.
