### PR TITLE
fix findPackageDir

### DIFF
--- a/lib/get-package-json.js
+++ b/lib/get-package-json.js
@@ -12,7 +12,8 @@ function findPackageDir(paths) {
     for (var i = 0; i < paths.length; ++i) {
         var dir = path.dirname(paths[i]);
         var dirName = dir.split(path.sep).pop();
-        if (dirName !== packageName) {
+        // TODO: it is wrong: dirName !== packageName
+        if (dirName === packageName) {
             return dir;
         }
     }


### PR DESCRIPTION
I guess the intelli-espower-loader aims to find the package.json file under intelli-espower-loader, and get the test directory name from the package.json file, so 

```javascript:
function findPackageDir(paths) {
    if (!paths) {
        return null;
    }

    for (var i = 0; i < paths.length; ++i) {
        var dir = path.dirname(paths[i]);
        var dirName = dir.split(path.sep).pop();
        ////////////////////////////////////////////////////////
        // only === works
        ////////////////////////////////////////////////////////
        if (dirName === packageName) {
            return dir;
        }
    }
}
```