### PR TITLE
feat: support pnpm

### DIFF
--- a/lib/get-package-json.js
+++ b/lib/get-package-json.js
@@ -4,6 +4,7 @@
 var assert = require("assert");
 var path = require("path");
 var packageName = require("../package.json").name;
+var packageNameReg = new RegExp('^' + packageName); // for support nodejs < 4.x, same as 'startsWith'
 
 function findPackageDir(paths) {
     if (!paths) {
@@ -12,8 +13,10 @@ function findPackageDir(paths) {
     for (var i = 0; i < paths.length; ++i) {
         var dir = path.dirname(paths[i]);
         var dirName = dir.split(path.sep).pop();
-        if (dirName !== packageName) {
-            return dir;
+
+        // ignore self and `.pnpm`. (support pnpm install)
+        if (!packageNameReg.test(dirName) && dirName !== '.pnpm') {
+          return dir;
         }
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10141527/113238977-5915e680-92dc-11eb-9681-fab08f1e3f44.png)
The value of "module.paths" of using "**npm i**" or "**pnpm i**"  is different.
```
// npm
[
  '/Users/userA/ProjectB/node_modules/intelli-espower-loader/node_modules',
  '/Users/userA/ProjectB/node_modules',
  '/Users/userA/node_modules',
  '/Users/node_modules',
  '/node_modules'
]
```

```
// pnpm
[
  '/Users/userA/ProjectB/node_modules/.pnpm/intelli-espower-loader@1.0.1/node_modules/intelli-espower-loader/node_modules',
  '/Users/userA/ProjectB/node_modules/.pnpm/intelli-espower-loader@1.0.1/node_modules',
  '/Users/userA/ProjectB/node_modules/.pnpm/node_modules',
  '/Users/userA/ProjectB/node_modules',
  '/Users/userA/node_modules',
  '/Users/node_modules',
  '/node_modules'
]
```
So in file "lib/get-package-json.js",  The function "findPackageDir" should ignore ".pnpm".